### PR TITLE
feat: v0.8.0 — HDF5 v2 format, pipeline param, atomic write, npy depr…

### DIFF
--- a/eegunity/_version.py
+++ b/eegunity/_version.py
@@ -1,3 +1,3 @@
 """Project version information."""
 
-__version__ = "0.7.0"
+__version__ = "0.8.0"

--- a/eegunity/modules/batch/eeg_batch.py
+++ b/eegunity/modules/batch/eeg_batch.py
@@ -1434,7 +1434,8 @@ class EEGBatch(_UDatasetSharedAttributes, EEGBatchMixinEpoch):
         return None
 
     def export_h5Dataset(self, output_path: str, name: str = 'EEGUnity_export',
-                         get_data_row_params: Dict = None, miss_bad_data: bool = False) -> None:
+                         get_data_row_params: Dict = None, miss_bad_data: bool = False,
+                         pipeline: Optional[Callable] = None) -> None:
         """
         Export the dataset in HDF5 format to the specified output path.
 
@@ -1463,6 +1464,9 @@ class EEGBatch(_UDatasetSharedAttributes, EEGBatchMixinEpoch):
         miss_bad_data : bool, optional
             If `True`, skips rows that contain bad data without raising an error.
             If `False`, raises an exception when encountering bad data.
+        pipeline : callable, optional
+            A user-supplied preprocessing function applied to each raw recording
+            after loading: ``raw = pipeline(raw)``.
         Returns
         -------
         None
@@ -1489,15 +1493,7 @@ class EEGBatch(_UDatasetSharedAttributes, EEGBatchMixinEpoch):
         if not os.path.exists(output_path):
             raise FileNotFoundError(f"Output path does not exist: {output_path}")
 
-        # Create the HDF5 file path
-        h5_path = Path(output_path) / f"{name}.hdf5"
-
-        # Check if the HDF5 file already exists
-        if h5_path.exists():
-            raise FileExistsError(
-                f"The HDF5 file '{h5_path}' already exists. Please choose a different name or delete the existing file.")
-
-        # Create the HDF5 file handler
+        # Create the HDF5 file handler (raises FileExistsError if <name>.hdf5 exists)
         dataset = h5Dataset(Path(output_path), name)
 
         # Parallel read; sequential HDF5 write in the main thread.
@@ -1507,6 +1503,8 @@ class EEGBatch(_UDatasetSharedAttributes, EEGBatchMixinEpoch):
         @log_processing
         def app_func(row):
             raw = self._get_data_row(row, **get_data_row_params)
+            if pipeline is not None:
+                raw = pipeline(raw)
             current_channels = list(raw.info.get('ch_names', []))
             current_sf = int(float(raw.info.get('sfreq', row['Sampling Rate'])))
             eeg_data = raw.get_data()
@@ -1533,8 +1531,7 @@ class EEGBatch(_UDatasetSharedAttributes, EEGBatchMixinEpoch):
 
         # Save the dataset to disk
         dataset.save()
-        # Print completion message if verbose is True
-        print(f"All data exported successfully to {h5_path}.")
+        print(f"All data exported successfully to {Path(output_path) / f'{name}.hdf5'}.")
 
     def auto_domain(self) -> None:
         """Automatically modify the 'Domain Tag' of each row based on 'Sampling Rate' and channel names.

--- a/eegunity/modules/batch/method_mixin_epoch.py
+++ b/eegunity/modules/batch/method_mixin_epoch.py
@@ -1,63 +1,42 @@
 import json
 import os
+import warnings
 import mne
 import numpy as np
 import pandas as pd
 from pathlib import Path
-from typing import Dict
+from typing import Callable, Dict, List, Optional
 import pickle
 from eegunity.modules.parser.eeg_parser import extract_events
-from eegunity.utils.h5 import h5Dataset
+from eegunity.utils.h5 import h5Dataset, h5EpochDatasetV2
 from eegunity.utils.handle_errors import handle_errors
 from eegunity.utils.log_processing import log_processing
 from eegunity.utils.label_channel import resample_raw_with_labels
+
+_V1_DEPRECATION_MSG = (
+    "format_version='v1' is deprecated and will be removed in a future release. "
+    "Use format_version='v2' (default) for better IO performance, smaller file size, "
+    "and PyTorch-friendly random access."
+)
 class EEGBatchMixinEpoch:
-    def epoch_by_event(self, output_path: str,
-                       exclude_bad: bool = True, miss_bad_data: bool = False,
-                       get_data_row_params: Dict = None,
-                       resample_params: Dict = None,
-                       epoch_params: Dict = None) -> None:
+    def epoch_by_event(self, *args, **kwargs) -> None:
         """
-        Batch process EEG data to create epochs based on events specified in the event_id column. The output is saved in
-        multiple .npy files for clarity and ease of use. This function serves as one of the available interfaces for
-        epoch processing. Given the existence of multiple interfaces for handling epochs, we recommend using the
-        unified processing interface designed specifically for this purpose. For more details, please refer to the
-        documentation for UnifiedDataset.EEGBatch.process_epochs().
-
-        Parameters
-        ----------
-        output_path : str
-            Directory to save the processed epochs.
-        exclude_bad : bool, optional
-            Whether to exclude bad epochs. Uses simple heuristics to determine bad epochs. Default is `True`.
-        miss_bad_data : bool, optional
-            Whether to skip files with processing errors. Default is `False`.
-        get_data_row_params : dict, optional
-            Additional parameters passed to `get_data_row()` for data retrieval.
-        resample_params : dict, optional
-            Parameters for resampling the raw data. Must include `sfreq` for the target sampling frequency.
-            Example: `{'sfreq': 256, 'npad': 'auto'}`.
-        epoch_params : dict, optional
-            Additional parameters for `mne.Epochs`, excluding `raw_data`, `events`, and `event_id`.
-
-        Returns
-        -------
-        None
-            The function modifies the dataset in place by creating and saving the epochs.
+        .. deprecated::
+            This method is no longer maintained and will be removed in a future
+            release. Use :meth:`epoch_by_event_hdf5` instead, which produces a
+            single HDF5 file with significantly faster IO and smaller storage.
 
         Raises
         ------
-        ValueError
-            If any parameters are inconsistent or if the specified output path is invalid.
+        NotImplementedError
+            Always. Migrate to ``epoch_by_event_hdf5``.
         """
-
-        # Set default empty dictionaries if parameters are None
-        if get_data_row_params is None:
-            get_data_row_params = {}
-        if resample_params is None:
-            resample_params = {}
-        if epoch_params is None:
-            epoch_params = {}
+        raise NotImplementedError(
+            "epoch_by_event() (npy output) is no longer maintained. "
+            "Use epoch_by_event_hdf5() instead: it produces a single HDF5 file "
+            "with faster random-access IO and smaller file size. "
+            "See the EEGUnity documentation for migration details."
+        )
 
         # Convert output_path to an absolute path
         output_path = os.path.abspath(output_path)
@@ -157,254 +136,90 @@ class EEGBatchMixinEpoch:
         print(f"Index file saved to {index_path}")
 
 
-    def epoch_by_long_event(self, output_path: str,
-                            overlap: float,
-                            exclude_bad: bool = True,
-                            miss_bad_data: bool = False,
-                            get_data_row_params: Dict = None,
-                            resample_params: Dict = None,
-                            epoch_params: Dict = None) -> None:
+    def epoch_by_long_event(self, *args, **kwargs) -> None:
         """
-        Batch process EEG data to create epochs for long-duration events with overlapping segments.
-        This function serves as one of the available interfaces for epoch processing. Given the existence of multiple
-        interfaces for handling epochs, we recommend using the unified processing interface designed specifically for
-        this purpose. For more details, please refer to the documentation for UnifiedDataset.EEGBatch.process_epochs().
-
-        Parameters
-        ----------
-        output_path : str
-            Directory to save the processed epochs.
-        overlap : float
-            Proportion of overlap between consecutive segments (0.0 to 1.0).
-        exclude_bad : bool, optional
-            Whether to exclude bad epochs. Uses simple heuristics to determine bad epochs. Default is `True`.
-        miss_bad_data : bool, optional
-            Whether to skip files with processing errors. Default is `False`.
-        get_data_row_params : dict, optional
-            Additional parameters passed to `get_data_row()` for data retrieval.
-        resample_params : dict, optional
-            Parameters for resampling the raw data. Must include `sfreq` for the target sampling frequency.
-            Example: `{'sfreq': 256, 'npad': 'auto'}`.
-        epoch_params : dict, optional
-            Additional parameters for `mne.Epochs`, excluding `raw_data`, `events`, and `event_id`.
-
-        Returns
-        -------
-        None
-            The function modifies the dataset in place by creating and saving the epochs.
+        .. deprecated::
+            This method is no longer maintained and will be removed in a future
+            release. Use :meth:`epoch_by_long_event_hdf5` instead, which produces
+            a single HDF5 file with significantly faster IO and smaller storage.
 
         Raises
         ------
-        ValueError
-            If any parameters are inconsistent or if the specified output path is invalid.
+        NotImplementedError
+            Always. Migrate to ``epoch_by_long_event_hdf5``.
         """
-        # Set default empty dictionaries if parameters are None
-        if get_data_row_params is None:
-            get_data_row_params = {}
-        if resample_params is None:
-            resample_params = {}
-        if epoch_params is None:
-            epoch_params = {}
-
-        if not 0.0 <= overlap < 1.0:
-            raise ValueError("Overlap must be between 0.0 (no overlap) and less than 1.0.")
-
-        # Convert output_path to an absolute path
-        output_path = os.path.abspath(output_path)
-
-        # Initialize index.csv
-        index_path = os.path.join(output_path, "index.csv")
-
-        @handle_errors(miss_bad_data)
-        def app_func(row, output_path: str,
-                     overlap: float,
-                     exclude_bad: bool = True,
-                     get_data_row_params: Dict = None,
-                     resample_params: Dict = None,
-                     epoch_params: Dict = None):
-            """Apply function to process individual rows."""
-            print(f"Processing File: {row['File Path']}")
-
-            # Load raw data with additional parameters
-            raw_data = self._get_data_row(row, **get_data_row_params)
-
-            # Resample if resample_params includes `sfreq`
-            if 'sfreq' in resample_params:
-                resample_raw_with_labels(raw_data, **resample_params)
-
-            # Check for annotations in the raw data
-            annotations = raw_data.annotations
-            if not annotations:
-                raise ValueError(f"No annotations found in the raw data for {row['File Path']}.")
-
-            # Extract epoch length from epoch_params
-            t_min = epoch_params.get('tmin', 0)
-            t_max = epoch_params.get('tmax', 1)
-            epoch_length = t_max - t_min  # Duration in seconds
-
-            # Create temporary annotations for segmentation of long events
-            temp_annotations = []
-            for onset, duration, description in zip(annotations.onset, annotations.duration,
-                                                    annotations.description):
-                if duration > epoch_length:
-                    # Calculate the step size based on overlap
-                    step = epoch_length * (1 - overlap)
-                    num_segments = int((duration - epoch_length) // step) + 1
-                    for i in range(num_segments):
-                        segment_start = onset + i * step
-                        temp_annotations.append((segment_start, epoch_length, description))
-
-            if not temp_annotations:
-                raise ValueError(
-                    f"For long events (such as sleep stages), the duration must be greater than (t_max - t_min). "
-                    f"Current duration is {duration}s, while the segmentation length is {t_max - t_min}s. "
-                    "Please check the event duration or the 'epoch_param' settings."
-                )
-
-            # Convert the temporary annotations to mne.Annotations
-            long_event_annotations = mne.Annotations(
-                onset=[a[0] for a in temp_annotations],
-                duration=[a[1] for a in temp_annotations],
-                description=[a[2] for a in temp_annotations]
-            )
-            raw_data.set_annotations(long_event_annotations)
-
-            # Create epochs based on the temporary annotations
-            events, event_id_map = mne.events_from_annotations(raw_data)
-            epochs = mne.Epochs(raw_data, events, event_id_map, **epoch_params)
-
-            # Exclude bad epochs
-            if exclude_bad:
-                epochs.drop_bad()
-
-            available_descriptions = list(epochs.event_id.keys())
-
-            # Collect index entries for this file
-            local_index_data = []
-
-            # Save each segmented epoch
-            for description in available_descriptions:
-                event_epochs = epochs[description]
-                file_name = os.path.splitext(os.path.basename(row['File Path']))[0]
-                event_output_path = os.path.join(output_path, description)
-                os.makedirs(event_output_path, exist_ok=True)
-
-                file_path = os.path.abspath(
-                    os.path.join(event_output_path, f"{file_name}_{description}_epoch.npy")
-                )
-                try:
-                    # Validate data export
-                    epoch_data = event_epochs.get_data()
-                    if epoch_data.ndim != 3:
-                        raise ValueError("Epoch data is not three-dimensional.")
-
-                    # Save data
-                    np.save(file_path, epoch_data)
-                    print(f"Epoch File was saved to {file_path}")
-
-                    # Gather metadata for index.csv
-                    local_index_data.append({
-                        "File Path": file_path,
-                        "Class Name": description,
-                        "Number of Epoch": len(event_epochs),
-                        "Channel Names": ",".join(event_epochs.info['ch_names']),
-                        "Comment": ""
-                    })
-                except Exception as e:
-                    local_index_data.append({
-                        "File Path": file_path,
-                        "Class Name": description,
-                        "Number of Epoch": "",
-                        "Channel Names": "",
-                        "Comment": str(e)
-                    })
-
-            return local_index_data
-
-        # Use batch_process to process data and collect results
-        results = self.batch_process(
-            lambda row: True,
-            lambda row: app_func(
-                row,
-                output_path,
-                overlap,
-                exclude_bad=exclude_bad,
-                get_data_row_params=get_data_row_params,
-                resample_params=resample_params,
-                epoch_params=epoch_params
-            ),
-            is_patch=False,
-            result_type='value',
-            execution_mode='process',
+        raise NotImplementedError(
+            "epoch_by_long_event() (npy output) is no longer maintained. "
+            "Use epoch_by_long_event_hdf5() instead: it produces a single HDF5 file "
+            "with faster random-access IO and smaller file size. "
+            "See the EEGUnity documentation for migration details."
         )
-
-        # Merge index_data from all results in main thread
-        index_data = []
-        for item in results:
-            if item is not None and isinstance(item, list):
-                index_data.extend(item)
-
-        # Save index.csv
-        pd.DataFrame(index_data).to_csv(index_path, index=False)
-        print(f"Index file saved to {index_path}")
 
 
     def epoch_by_event_hdf5(self, output_path: str,
                             exclude_bad: bool = True,
                             file_name_prefix: str = "EpochData",
                             miss_bad_data: bool = False,
+                            include_events: Optional[List[str]] = None,
+                            format_version: str = 'v2',
                             get_data_row_params: Dict = None,
                             resample_params: Dict = None,
-                            epoch_params: Dict = None) -> None:
+                            epoch_params: Dict = None,
+                            pipeline: Optional[Callable] = None) -> None:
         """
-        Batch process EEG data to create epochs based on events specified in the event_id column,
-        save the results in HDF5 format, and generate a JSON file with event counts.
-        This function serves as one of the available interfaces for epoch processing. Given the existence of multiple
-        interfaces for handling epochs, we recommend using the unified processing interface designed specifically for
-        this purpose. For more details, please refer to the documentation for UnifiedDataset.EEGBatch.process_epochs().
+        Batch process EEG data to create epochs based on events and save as HDF5.
 
-        **Continuous regression labels via misc channels** - if the raw object
-        contains ``misc:`` label channels (added by a dataset-specific kernel,
-        see :mod:`eegunity.utils.label_channel`), they are included in the
-        epoch array alongside the EEG channels.  The ``chOrder`` attribute of
-        every HDF5 event dataset reflects all channels, including ``misc:``
-        ones::
+        **v2 format (default)** — flat array layout optimised for PyTorch random
+        access and storage efficiency:
 
-            {group_name}/{event_name}   # float array [n_epochs, n_ch_total, n_times]
-                attrs:
-                    chOrder : [...'eeg:Fz', ..., 'misc:reaction_time']
-                    rsFreq  : float
+        - ``data`` array: ``(N, n_ch, n_times)`` float32, gzip-1, chunk per epoch.
+        - ``epoch_meta/source_group``: source file name for each epoch.
+        - ``epoch_meta/event_code``: integer class code for each epoch.
+        - ``source_meta/{group}/``: per-file attrs + pickled ``mne.Info``.
+        - Root attrs include ``label_map`` (JSON: code → event name).
 
-        Downstream code can retrieve misc channel values by name from
-        ``chOrder`` (see :class:`~dataset_example.RegressionEpochDataset`).
-        Existing code that does not reference ``misc:`` channels is unaffected.
+        **v1 format** — legacy file-per-group layout (deprecated, will be removed
+        in a future release).
 
         Parameters
         ----------
         output_path : str
             Directory to save the processed epochs.
         exclude_bad : bool, optional
-            Whether to exclude bad epochs. Uses simple heuristics to determine bad epochs. Default is `True`.
+            Whether to exclude bad epochs. Default is ``True``.
         file_name_prefix : str, optional
-            The filename prefix to save hdf5 and event info file. Default is `EpochData`.
+            Filename prefix for the HDF5 file. Default is ``'EpochData'``.
         miss_bad_data : bool, optional
-            Whether to skip files with processing errors. Default is `False`.
+            Whether to skip files with processing errors. Default is ``False``.
+        include_events : list of str, optional
+            Whitelist of event names to include. If ``None``, all events are
+            saved. Use this to exclude noise events (e.g. ``'Start of a trial'``).
+        format_version : str, optional
+            ``'v2'`` (default, recommended) or ``'v1'`` (deprecated).
         get_data_row_params : dict, optional
-            Additional parameters passed to `get_data_row()` for data retrieval.
+            Additional parameters passed to ``get_data_row()``.
         resample_params : dict, optional
-            Parameters for resampling the raw data. Must include `sfreq` for the target sampling frequency.
-            ``misc:`` channels are resampled with nearest-neighbour interpolation automatically.
-            Example: `{'sfreq': 256, 'npad': 'auto'}`.
+            Parameters for resampling. Must include ``sfreq`` for target rate.
         epoch_params : dict, optional
-            Additional parameters for `mne.Epochs`, excluding `raw_data`, `events`, and `event_id`.
+            Additional parameters for ``mne.Epochs``.
+        pipeline : callable, optional
+            A user-supplied preprocessing function applied to each raw recording
+            *after* loading and *before* resampling:
+            ``raw = pipeline(raw)``.
+            If ``pipeline`` itself performs resampling and ``resample_params``
+            is also provided, the final resample (from ``resample_params``)
+            will still be applied afterwards — ``resample_params`` always runs
+            last. To avoid double-resampling, either omit ``resample_params``
+            when the pipeline already resamples, or ensure both target the same
+            sampling frequency.
 
-        Returns
-        -------
-        None
-            The function modifies the dataset in place by creating and saving the epochs in HDF5 format,
-            and generates an event_info.json file.
+        Raises
+        ------
+        ValueError
+            If recordings have inconsistent channel counts. Use
+            ``eeg_batch.auto_domain()`` + ``group_by_domain()`` to split them
+            first, then call this function on each sub-dataset separately.
         """
-        # Set default empty dictionaries if parameters are None
         if get_data_row_params is None:
             get_data_row_params = {}
         if resample_params is None:
@@ -412,146 +227,162 @@ class EEGBatchMixinEpoch:
         if epoch_params is None:
             epoch_params = {}
 
-        # Ensure output_path exists
         output_path = os.path.abspath(output_path)
         os.makedirs(output_path, exist_ok=True)
 
-        # Initialize HDF5 dataset
-        dataset = h5Dataset(Path(output_path), name=file_name_prefix)
+        if format_version == 'v1':
+            warnings.warn(_V1_DEPRECATION_MSG, DeprecationWarning, stacklevel=2)
+            self._epoch_by_event_hdf5_v1(
+                output_path, exclude_bad, file_name_prefix, miss_bad_data,
+                get_data_row_params, resample_params, epoch_params, pipeline)
+            return
 
-        # Dictionary to keep track of event counts
-        event_info = {}
+        # ---- v2 path ----
+        _check_channel_consistency(self)
+
+        dataset = h5EpochDatasetV2(Path(output_path), name=file_name_prefix)
 
         @handle_errors(miss_bad_data)
         @log_processing
-        def app_func(row, exclude_bad: bool = True,
-                     get_data_row_params: Dict = None,
-                     resample_params: Dict = None,
-                     epoch_params: Dict = None):
-            """
-            Process an individual file to create and save epochs.
-            """
+        def app_func(row):
             raw_data = self._get_data_row(row, **get_data_row_params)
-
-            # Resample raw data if necessary
+            if pipeline is not None:
+                raw_data = pipeline(raw_data)
             if 'sfreq' in resample_params:
                 resample_raw_with_labels(raw_data, **resample_params)
 
-            # Extract events
             events, event_id = extract_events(raw_data)
-
-            # Create epochs
             epochs = mne.Epochs(raw_data, events, event_id, **epoch_params)
-
-            # Exclude bad epochs
             if exclude_bad:
                 epochs.drop_bad()
 
-            # Create a group for the current file
             file_name = os.path.splitext(os.path.basename(row['File Path']))[0]
-            grp = dataset.addGroup(grpName=file_name)
-            # Add info dataset for the group
             info_bytes = pickle.dumps(raw_data.info)
-            info_array = np.frombuffer(info_bytes, dtype='uint8')
-            dataset.addDataset(grp, 'info', info_array, chunks=None)
-            # Iterate through each event type and save data
+            source_attrs = _extract_source_attrs(raw_data, row)
+
             for event in event_id:
-                try:
-                    event_epochs = epochs[event]
-                    epoch_data = event_epochs.get_data()
-
-                    if epoch_data.ndim != 3:
-                        raise ValueError("Epoch data is not three-dimensional.")
-
-                    # Add dataset for this event
-                    dset = dataset.addDataset(grp, event, epoch_data, chunks=epoch_data.shape)
-
-                    # Add attributes for the dataset.
-                    # chOrder includes all channels: EEG and any misc: label channels.
-                    dataset.addAttributes(dset, 'rsFreq', raw_data.info['sfreq'])
-                    dataset.addAttributes(dset, 'chOrder', event_epochs.info['ch_names'])
-
-                    # Update event counts
-                    event_info[event] = event_info.get(event, 0) + len(event_epochs)
-
-                    print(f"Processed and saved epochs for event: {event}")
-
-                except Exception as e:
-                    # Handle error and skip this event
-                    print(f"Error processing event '{event}': {e}")
+                if include_events is not None and event not in include_events:
                     continue
+                try:
+                    epoch_data = epochs[event].get_data()
+                    if epoch_data.ndim != 3 or epoch_data.shape[0] == 0:
+                        continue
+                    dataset.add_epochs(
+                        group_name=file_name,
+                        event_name=event,
+                        epoch_data=epoch_data,
+                        info_bytes=info_bytes,
+                        source_attrs=source_attrs,
+                        sfreq=raw_data.info['sfreq'],
+                        ch_names=raw_data.info['ch_names'],
+                    )
+                    print(f"  [{file_name}] event='{event}' n={epoch_data.shape[0]}")
+                except Exception as e:
+                    print(f"  [{file_name}] skipping event '{event}': {e}")
 
-            print(f"Processed and saved epochs for file: {file_name}")
-
-        # Use batch_process to process data - must be sequential (shared HDF5 handle)
         self.batch_process(
             lambda row: True,
-            lambda row: app_func(
-                row,
-                exclude_bad=exclude_bad,
-                get_data_row_params=get_data_row_params,
-                resample_params=resample_params,
-                epoch_params=epoch_params
-            ),
+            app_func,
             is_patch=False,
             result_type=None,
             execution_mode=None,
         )
 
-        # Save the HDF5 dataset
         dataset.save()
-        print(f"HDF5 dataset saved to {output_path}")
+        print(f"v2 HDF5 saved to {output_path}/{file_name_prefix}.hdf5")
 
-        # Save event_info.json
+    def _epoch_by_event_hdf5_v1(self, output_path, exclude_bad, file_name_prefix,
+                                 miss_bad_data, get_data_row_params,
+                                 resample_params, epoch_params, pipeline=None):
+        """Legacy v1 writer (file-per-group layout). Called by epoch_by_event_hdf5."""
+        dataset = h5Dataset(Path(output_path), name=file_name_prefix)
+        event_info = {}
+
+        @handle_errors(miss_bad_data)
+        @log_processing
+        def app_func(row):
+            raw_data = self._get_data_row(row, **get_data_row_params)
+            if pipeline is not None:
+                raw_data = pipeline(raw_data)
+            if 'sfreq' in resample_params:
+                resample_raw_with_labels(raw_data, **resample_params)
+            events, event_id = extract_events(raw_data)
+            epochs = mne.Epochs(raw_data, events, event_id, **epoch_params)
+            if exclude_bad:
+                epochs.drop_bad()
+            file_name = os.path.splitext(os.path.basename(row['File Path']))[0]
+            grp = dataset.addGroup(grpName=file_name)
+            info_bytes = pickle.dumps(raw_data.info)
+            dataset.addDataset(grp, 'info', np.frombuffer(info_bytes, dtype='uint8'), chunks=None)
+            for event in event_id:
+                try:
+                    event_epochs = epochs[event]
+                    epoch_data = event_epochs.get_data()
+                    if epoch_data.ndim != 3:
+                        raise ValueError("Epoch data is not three-dimensional.")
+                    dset = dataset.addDataset(grp, event, epoch_data, chunks=epoch_data.shape)
+                    dataset.addAttributes(dset, 'rsFreq', raw_data.info['sfreq'])
+                    dataset.addAttributes(dset, 'chOrder', event_epochs.info['ch_names'])
+                    event_info[event] = event_info.get(event, 0) + len(event_epochs)
+                except Exception as e:
+                    print(f"Error processing event '{event}': {e}")
+
+        self.batch_process(
+            lambda row: True, app_func,
+            is_patch=False, result_type=None, execution_mode=None,
+        )
+        dataset.save()
         event_info_path = os.path.join(output_path, file_name_prefix + "_event_info.json")
         with open(event_info_path, 'w') as f:
             json.dump(event_info, f, indent=4)
-        print(f"Event information saved to {event_info_path}")
+        print(f"v1 HDF5 saved to {output_path}")
 
     def epoch_by_segmentation_hdf5(self, output_path: str,
                                    exclude_bad: bool = True,
                                    file_name_prefix: str = "EpochData",
                                    miss_bad_data: bool = False,
+                                   format_version: str = 'v2',
                                    get_data_row_params: Dict = None,
                                    resample_params: Dict = None,
                                    segment_params: Dict = None,
-                                   epoch_params: Dict = None) -> None:
+                                   epoch_params: Dict = None,
+                                   pipeline: Optional[Callable] = None) -> None:
         """
-        Batch process EEG data to create epochs by sliding window segmentation,
-        save the results in HDF5 format, and generate a JSON file with event counts.
+        Batch process EEG data to create epochs by sliding-window segmentation
+        and save as HDF5.
 
-        .. note::
-            ``misc:`` label channels added by kernels are preserved in the
-            epoch array (they are channel data, not annotations, and survive
-            sliding-window segmentation).  The value at the epoch midpoint
-            can be retrieved via ``chOrder`` using
-            :class:`~dataset_example.RegressionEpochDataset`.  However, each
-            segment shares the same misc channel signal as the source recording,
-            so the label semantics depend on how the kernel filled the channel.
+        See ``epoch_by_event_hdf5`` for documentation of the v2 file format.
 
         Parameters
         ----------
         output_path : str
             Directory to save the processed epochs.
         exclude_bad : bool, optional
-            Whether to exclude bad epochs. Default is `True`.
+            Whether to exclude bad epochs. Default is ``True``.
         file_name_prefix : str, optional
-            The filename prefix to save hdf5 and event info file. Default is `EpochData`.
+            Filename prefix for the HDF5 file. Default is ``'EpochData'``.
         miss_bad_data : bool, optional
-            Whether to skip files with processing errors. Default is `False`.
+            Whether to skip files with processing errors. Default is ``False``.
+        format_version : str, optional
+            ``'v2'`` (default, recommended) or ``'v1'`` (deprecated).
         get_data_row_params : dict, optional
-            Additional parameters passed to `get_data_row()` for data retrieval.
+            Additional parameters passed to ``get_data_row()``.
         resample_params : dict, optional
-            Parameters for resampling the raw data. Must include `sfreq` for the target sampling frequency.
+            Parameters for resampling.
         segment_params : dict, optional
-            Parameters for segmentation. Must include 'segment_length' (in seconds) and 'overlap' (float between 0-1).
-            Example: `{'segment_length': 2.0, 'overlap': 0.5}`.
+            Must include ``'segment_length'`` (seconds) and ``'overlap'`` (0–1).
         epoch_params : dict, optional
-            Additional parameters for `mne.Epochs`, excluding 'raw', 'events', and 'event_id'.
+            Additional parameters for ``mne.Epochs``.
+        pipeline : callable, optional
+            Preprocessing function applied after loading and before resampling:
+            ``raw = pipeline(raw)``. See ``epoch_by_event_hdf5`` for details on
+            the pipeline/resample_params ordering.
 
-        Returns
-        -------
-        None
+        Raises
+        ------
+        ValueError
+            If recordings have inconsistent channel counts. Use
+            ``eeg_batch.auto_domain()`` + ``group_by_domain()`` first.
         """
         if get_data_row_params is None:
             get_data_row_params = {}
@@ -565,155 +396,181 @@ class EEGBatchMixinEpoch:
         if 'segment_length' not in segment_params or 'overlap' not in segment_params:
             raise ValueError("segment_params must include 'segment_length' and 'overlap' keys.")
 
-
         output_path = os.path.abspath(output_path)
         os.makedirs(output_path, exist_ok=True)
 
+        if format_version == 'v1':
+            warnings.warn(_V1_DEPRECATION_MSG, DeprecationWarning, stacklevel=2)
+            self._epoch_by_segmentation_hdf5_v1(
+                output_path, exclude_bad, file_name_prefix, miss_bad_data,
+                get_data_row_params, resample_params, segment_params, epoch_params, pipeline)
+            return
+
+        # ---- v2 path ----
+        _check_channel_consistency(self)
+
+        dataset = h5EpochDatasetV2(Path(output_path), name=file_name_prefix)
+
+        @handle_errors(miss_bad_data)
+        @log_processing
+        def app_func(row):
+            raw_data = self._get_data_row(row, **get_data_row_params)
+            if pipeline is not None:
+                raw_data = pipeline(raw_data)
+            if 'sfreq' in resample_params:
+                resample_raw_with_labels(raw_data, **resample_params)
+
+            sfreq = raw_data.info['sfreq']
+            segment_length = segment_params['segment_length']
+            overlap = segment_params['overlap']
+            window_size = int(segment_length * sfreq)
+            step_size = int(window_size * (1 - overlap))
+            onset_samples = np.arange(0, raw_data.n_times - window_size + 1, step_size)
+            n_segments = len(onset_samples)
+
+            file_name = os.path.splitext(os.path.basename(row['File Path']))[0]
+            segment_event_name = 'Segment'
+
+            events = np.zeros((n_segments, 3), dtype=int)
+            events[:, 0] = onset_samples
+            events[:, 2] = 1
+            epoch_id = {segment_event_name: 1}
+
+            epochs = mne.Epochs(raw_data, events, epoch_id,
+                                tmin=0, tmax=segment_length, **epoch_params)
+            if exclude_bad:
+                epochs.drop_bad()
+
+            epoch_data = epochs.get_data()
+            if epoch_data.ndim != 3 or epoch_data.shape[0] == 0:
+                return
+
+            info_bytes = pickle.dumps(raw_data.info)
+            source_attrs = _extract_source_attrs(raw_data, row)
+            dataset.add_epochs(
+                group_name=file_name,
+                event_name=segment_event_name,
+                epoch_data=epoch_data,
+                info_bytes=info_bytes,
+                source_attrs=source_attrs,
+                sfreq=sfreq,
+                ch_names=raw_data.info['ch_names'],
+            )
+            print(f"  [{file_name}] {epoch_data.shape[0]} segments saved")
+
+        self.batch_process(
+            lambda row: True, app_func,
+            is_patch=False, result_type=None, execution_mode=None,
+        )
+        dataset.save()
+        print(f"v2 HDF5 saved to {output_path}/{file_name_prefix}.hdf5")
+
+    def _epoch_by_segmentation_hdf5_v1(self, output_path, exclude_bad,
+                                        file_name_prefix, miss_bad_data,
+                                        get_data_row_params, resample_params,
+                                        segment_params, epoch_params, pipeline=None):
+        """Legacy v1 sliding-window writer."""
         dataset = h5Dataset(Path(output_path), name=file_name_prefix)
         event_info = {}
 
         @handle_errors(miss_bad_data)
         @log_processing
-        def app_func(row, exclude_bad: bool = True,
-                     get_data_row_params: Dict = None,
-                     resample_params: Dict = None,
-                     segment_params: Dict = None,
-                     epoch_params: Dict = None):
-            """
-            Process an individual file to create and save sliding window epochs.
-            """
+        def app_func(row):
             raw_data = self._get_data_row(row, **get_data_row_params)
-
+            if pipeline is not None:
+                raw_data = pipeline(raw_data)
             if 'sfreq' in resample_params:
                 resample_raw_with_labels(raw_data, **resample_params)
-
             sfreq = raw_data.info['sfreq']
-            n_samples = raw_data.n_times
-
             segment_length = segment_params['segment_length']
             overlap = segment_params['overlap']
-
             window_size = int(segment_length * sfreq)
             step_size = int(window_size * (1 - overlap))
-
-            onset_samples = np.arange(0, n_samples - window_size + 1, step_size)
+            onset_samples = np.arange(0, raw_data.n_times - window_size + 1, step_size)
             n_segments = len(onset_samples)
-
             file_name = os.path.splitext(os.path.basename(row['File Path']))[0]
             segment_event_name = f"{file_name}_Segment"
-
-            # MNE event structure: (onset_sample, 0, event_id)
             events = np.zeros((n_segments, 3), dtype=int)
             events[:, 0] = onset_samples
-            events[:, 2] = 1  # dummy event value (required but not actually used later)
-
+            events[:, 2] = 1
             event_id = {segment_event_name: 1}
-
             epochs = mne.Epochs(raw_data, events, event_id,
                                 tmin=0, tmax=segment_length, **epoch_params)
-
             if exclude_bad:
                 epochs.drop_bad()
-
             grp = dataset.addGroup(grpName=file_name)
-
             info_bytes = pickle.dumps(raw_data.info)
-            info_array = np.frombuffer(info_bytes, dtype='uint8')
-            dataset.addDataset(grp, 'info', info_array, chunks=None)
-
+            dataset.addDataset(grp, 'info', np.frombuffer(info_bytes, dtype='uint8'), chunks=None)
             try:
                 epoch_data = epochs.get_data()
-
                 if epoch_data.ndim != 3:
                     raise ValueError("Epoch data is not three-dimensional.")
-
                 dset = dataset.addDataset(grp, segment_event_name, epoch_data, chunks=epoch_data.shape)
-
-                dataset.addAttributes(dset, 'rsFreq', raw_data.info['sfreq'])
+                dataset.addAttributes(dset, 'rsFreq', sfreq)
                 dataset.addAttributes(dset, 'chOrder', epochs.info['ch_names'])
-
-                # Update event counts
                 event_info[segment_event_name] = event_info.get(segment_event_name, 0) + len(epochs)
-
-                print(f"Processed and saved {len(epochs)} segments for event: {segment_event_name}")
-
             except Exception as e:
                 print(f"Error processing segmented epochs: {e}")
 
-        # Must be sequential - app_func writes directly to a shared HDF5 handle
         self.batch_process(
-            lambda row: True,
-            lambda row: app_func(
-                row,
-                exclude_bad=exclude_bad,
-                get_data_row_params=get_data_row_params,
-                resample_params=resample_params,
-                segment_params=segment_params,
-                epoch_params=epoch_params
-            ),
-            is_patch=False,
-            result_type=None,
-            execution_mode=None,
+            lambda row: True, app_func,
+            is_patch=False, result_type=None, execution_mode=None,
         )
-
         dataset.save()
-        print(f"HDF5 dataset saved to {output_path}")
-
         event_info_path = os.path.join(output_path, file_name_prefix + "_event_info.json")
         with open(event_info_path, 'w') as f:
             json.dump(event_info, f, indent=4)
-        print(f"Event information saved to {event_info_path}")
+        print(f"v1 HDF5 saved to {output_path}")
 
     def epoch_by_long_event_hdf5(self, output_path: str,
                                  overlap: float,
                                  file_name_prefix: str = "EpochData",
                                  exclude_bad: bool = True,
                                  miss_bad_data: bool = False,
+                                 include_events: Optional[List[str]] = None,
+                                 format_version: str = 'v2',
                                  get_data_row_params: Dict = None,
                                  resample_params: Dict = None,
-                                 epoch_params: Dict = None) -> None:
+                                 epoch_params: Dict = None,
+                                 pipeline: Optional[Callable] = None) -> None:
         """
-        Batch process EEG data to create epochs for long-duration events with overlapping segments
-        and save the results in HDF5 format. Also generates event_info.json containing event counts.
-        This function serves as one of the available interfaces for epoch processing. Given the existence of multiple
-        interfaces for handling epochs, we recommend using the unified processing interface designed specifically for
-        this purpose. For more details, please refer to the documentation for UnifiedDataset.EEGBatch.process_epochs().
+        Batch process EEG data to create epochs from long-duration events
+        (with overlap) and save as HDF5.
 
-        .. note::
-            ``misc:`` label channels added by kernels are preserved in the
-            epoch array even though ``raw.annotations`` is replaced internally
-            with the segmented long-event annotations.  Channel data survives
-            annotation replacement.  The label value at each segment's midpoint
-            can be retrieved via :class:`~dataset_example.RegressionEpochDataset`.
+        See ``epoch_by_event_hdf5`` for documentation of the v2 file format.
 
         Parameters
         ----------
         output_path : str
             Directory to save the processed epochs.
         overlap : float
-            Proportion of overlap between consecutive segments (0.0 to 1.0).
+            Overlap between consecutive segments (0.0 ≤ overlap < 1.0).
         file_name_prefix : str, optional
-            The filename prefix to save hdf5 and event info file. Default is `EpochData`.
+            Filename prefix for the HDF5 file. Default is ``'EpochData'``.
         exclude_bad : bool, optional
-            Whether to exclude bad epochs. Default is `True`.
+            Whether to exclude bad epochs. Default is ``True``.
         miss_bad_data : bool, optional
-            Whether to skip files with processing errors. Default is `False`.
+            Whether to skip files with processing errors. Default is ``False``.
+        include_events : list of str, optional
+            Whitelist of event names to include. ``None`` keeps all events.
+        format_version : str, optional
+            ``'v2'`` (default, recommended) or ``'v1'`` (deprecated).
         get_data_row_params : dict, optional
-            Additional parameters passed to `get_data_row()` for data retrieval.
+            Additional parameters passed to ``get_data_row()``.
         resample_params : dict, optional
-            Parameters for resampling the raw data.
+            Parameters for resampling.
         epoch_params : dict, optional
-            Additional parameters for `mne.Epochs`.
-
-        Returns
-        -------
-        None
-            The function creates and saves the epochs in HDF5 format and event_info.json.
+            Additional parameters for ``mne.Epochs``.
+        pipeline : callable, optional
+            Preprocessing function applied after loading and before resampling:
+            ``raw = pipeline(raw)``. See ``epoch_by_event_hdf5`` for details on
+            the pipeline/resample_params ordering.
 
         Raises
         ------
         ValueError
-            If any parameters are inconsistent.
+            If recordings have inconsistent channel counts. Use
+            ``eeg_batch.auto_domain()`` + ``group_by_domain()`` first.
         """
         if get_data_row_params is None:
             get_data_row_params = {}
@@ -728,111 +585,156 @@ class EEGBatchMixinEpoch:
         output_path = os.path.abspath(output_path)
         os.makedirs(output_path, exist_ok=True)
 
-        # Initialize the HDF5 dataset
-        dataset = h5Dataset(Path(output_path), name=file_name_prefix)
+        if format_version == 'v1':
+            warnings.warn(_V1_DEPRECATION_MSG, DeprecationWarning, stacklevel=2)
+            self._epoch_by_long_event_hdf5_v1(
+                output_path, overlap, exclude_bad, file_name_prefix, miss_bad_data,
+                get_data_row_params, resample_params, epoch_params, pipeline)
+            return
 
-        # Initialize event count dictionary
-        event_info = {}
+        # ---- v2 path ----
+        _check_channel_consistency(self)
+
+        dataset = h5EpochDatasetV2(Path(output_path), name=file_name_prefix)
 
         @handle_errors(miss_bad_data)
         def process_file(row):
-            """
-            Process an individual file to create epochs from long events.
-            """
-            print(f"Processing File: {row['File Path']}")
             raw_data = self._get_data_row(row, **get_data_row_params)
-
-            # Resample the raw data if necessary
+            if pipeline is not None:
+                raw_data = pipeline(raw_data)
             if 'sfreq' in resample_params:
                 resample_raw_with_labels(raw_data, **resample_params)
 
-            # Check for annotations
             annotations = raw_data.annotations
             if not annotations:
-                raise ValueError(f"No annotations found in the raw data for {row['File Path']}.")
+                raise ValueError(f"No annotations in {row['File Path']}.")
 
-            # Calculate epoch length and create overlapping segments
             t_min = epoch_params.get('tmin', 0)
             t_max = epoch_params.get('tmax', 1)
             epoch_length = t_max - t_min
 
             temp_annotations = []
-            for onset, duration, description in zip(annotations.onset, annotations.duration, annotations.description):
+            for onset, duration, description in zip(
+                    annotations.onset, annotations.duration, annotations.description):
                 if duration > epoch_length:
                     step = epoch_length * (1 - overlap)
                     num_segments = int((duration - epoch_length) // step) + 1
                     for i in range(num_segments):
-                        segment_start = onset + i * step
-                        temp_annotations.append((segment_start, epoch_length, description))
+                        temp_annotations.append(
+                            (onset + i * step, epoch_length, description))
 
             if not temp_annotations:
                 raise ValueError("No long events long enough for segmentation.")
 
-            # Convert the temporary annotations to mne.Annotations
-            long_event_annotations = mne.Annotations(
+            raw_data.set_annotations(mne.Annotations(
                 onset=[a[0] for a in temp_annotations],
                 duration=[a[1] for a in temp_annotations],
-                description=[a[2] for a in temp_annotations]
-            )
-            raw_data.set_annotations(long_event_annotations)
-
-            # Create epochs
+                description=[a[2] for a in temp_annotations],
+            ))
             events, event_id_map = mne.events_from_annotations(raw_data)
             epochs = mne.Epochs(raw_data, events, event_id_map, **epoch_params)
-
             if exclude_bad:
                 epochs.drop_bad()
 
-            # Create a group for the current file in HDF5
+            file_name = os.path.splitext(os.path.basename(row['File Path']))[0]
+            info_bytes = pickle.dumps(raw_data.info)
+            source_attrs = _extract_source_attrs(raw_data, row)
+
+            for description in event_id_map:
+                if include_events is not None and description not in include_events:
+                    continue
+                try:
+                    epoch_data = epochs[description].get_data()
+                    if epoch_data.ndim != 3 or epoch_data.shape[0] == 0:
+                        continue
+                    dataset.add_epochs(
+                        group_name=file_name,
+                        event_name=description,
+                        epoch_data=epoch_data,
+                        info_bytes=info_bytes,
+                        source_attrs=source_attrs,
+                        sfreq=raw_data.info['sfreq'],
+                        ch_names=raw_data.info['ch_names'],
+                    )
+                    print(f"  [{file_name}] event='{description}' n={epoch_data.shape[0]}")
+                except Exception as e:
+                    print(f"  [{file_name}] skipping event '{description}': {e}")
+
+        self.batch_process(
+            lambda row: row['Completeness Check'] != 'Unavailable',
+            lambda row: process_file(row),
+            is_patch=False, result_type=None, execution_mode=None,
+        )
+        dataset.save()
+        print(f"v2 HDF5 saved to {output_path}/{file_name_prefix}.hdf5")
+
+    def _epoch_by_long_event_hdf5_v1(self, output_path, overlap, exclude_bad,
+                                      file_name_prefix, miss_bad_data,
+                                      get_data_row_params, resample_params, epoch_params,
+                                      pipeline=None):
+        """Legacy v1 long-event writer."""
+        dataset = h5Dataset(Path(output_path), name=file_name_prefix)
+        event_info = {}
+
+        @handle_errors(miss_bad_data)
+        def process_file(row):
+            raw_data = self._get_data_row(row, **get_data_row_params)
+            if pipeline is not None:
+                raw_data = pipeline(raw_data)
+            if 'sfreq' in resample_params:
+                resample_raw_with_labels(raw_data, **resample_params)
+            annotations = raw_data.annotations
+            if not annotations:
+                raise ValueError(f"No annotations in {row['File Path']}.")
+            t_min = epoch_params.get('tmin', 0)
+            t_max = epoch_params.get('tmax', 1)
+            epoch_length = t_max - t_min
+            temp_annotations = []
+            for onset, duration, description in zip(
+                    annotations.onset, annotations.duration, annotations.description):
+                if duration > epoch_length:
+                    step = epoch_length * (1 - overlap)
+                    num_segments = int((duration - epoch_length) // step) + 1
+                    for i in range(num_segments):
+                        temp_annotations.append((onset + i * step, epoch_length, description))
+            if not temp_annotations:
+                raise ValueError("No long events long enough for segmentation.")
+            raw_data.set_annotations(mne.Annotations(
+                onset=[a[0] for a in temp_annotations],
+                duration=[a[1] for a in temp_annotations],
+                description=[a[2] for a in temp_annotations],
+            ))
+            events, event_id_map = mne.events_from_annotations(raw_data)
+            epochs = mne.Epochs(raw_data, events, event_id_map, **epoch_params)
+            if exclude_bad:
+                epochs.drop_bad()
             file_name = os.path.splitext(os.path.basename(row['File Path']))[0]
             grp = dataset.addGroup(grpName=file_name)
-            # Save info metadata
             info_bytes = pickle.dumps(raw_data.info)
-            info_array = np.frombuffer(info_bytes, dtype='uint8')
-            dataset.addDataset(grp, 'info', info_array, chunks=None)
-            # Save epochs to HDF5
+            dataset.addDataset(grp, 'info', np.frombuffer(info_bytes, dtype='uint8'), chunks=None)
             for description, event_id in event_id_map.items():
                 try:
                     event_epochs = epochs[description]
                     epoch_data = event_epochs.get_data()
-
                     if epoch_data.ndim != 3:
-                        raise ValueError("Epoch data is not three-dimensional.")
-
-                    # Add dataset for this event
+                        raise ValueError("Not 3D.")
                     dset = dataset.addDataset(grp, description, epoch_data, chunks=epoch_data.shape)
-
-                    # Add metadata
                     dataset.addAttributes(dset, 'rsFreq', raw_data.info['sfreq'])
                     dataset.addAttributes(dset, 'chOrder', event_epochs.info['ch_names'])
-
-                    # Update event_info
                     event_info[description] = event_info.get(description, 0) + len(event_epochs)
                 except Exception as e:
-                    # Handle error and skip this event
                     print(f"Error processing event '{description}': {e}")
-                    continue
 
-            print(f"Finished processing {file_name}.")
-
-        # Must be sequential - process_file writes directly to a shared HDF5 handle
         self.batch_process(
             lambda row: row['Completeness Check'] != 'Unavailable',
             lambda row: process_file(row),
-            is_patch=False,
-            result_type=None,
-            execution_mode=None,
+            is_patch=False, result_type=None, execution_mode=None,
         )
-
-        # Save the HDF5 dataset
         dataset.save()
-        print(f"Long-event epochs saved to {output_path}.")
-
-        # Save event_info.json
         event_info_path = os.path.join(output_path, file_name_prefix + "_event_info.json")
         with open(event_info_path, 'w') as f:
             json.dump(event_info, f, indent=4)
-        print(f"Event information saved to {event_info_path}.")
+        print(f"v1 HDF5 saved to {output_path}.")
 
 
     def process_epochs(self,
@@ -911,3 +813,40 @@ class EEGBatchMixinEpoch:
 
         # Call the selected method with the prepared arguments.
         method_mapping[(long_event, use_hdf5)](*args, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Module-level helpers (not methods — avoid cluttering the mixin namespace)
+# ---------------------------------------------------------------------------
+
+def _check_channel_consistency(batch_obj) -> None:
+    """Raise ValueError if the locator contains files with differing channel counts."""
+    locator = batch_obj.get_shared_attr()['locator']
+    available = locator[locator['Completeness Check'] != 'Unavailable']
+    unique_counts = available['Number of Channels'].astype(float).astype(int).unique()
+    if len(unique_counts) > 1:
+        raise ValueError(
+            f"Inconsistent channel counts detected: {sorted(unique_counts.tolist())}. "
+            "All recordings must have the same number of channels before exporting to "
+            "a flat HDF5 (v2) file. "
+            "Use eeg_batch.auto_domain() followed by group_by_domain() to split "
+            "recordings with different channel configurations into separate "
+            "UnifiedDataset instances, then call this function on each one."
+        )
+
+
+def _extract_source_attrs(raw, row) -> dict:
+    """Extract scalar metadata from a raw object and locator row."""
+    attrs = {'file_path': str(row.get('File Path', 'unknown'))}
+    try:
+        desc = json.loads(raw.info.get('description', '{}'))
+        eu = desc.get('eegunity_description', {})
+        attrs['age'] = eu.get('age', 'unknown')
+        attrs['gender'] = eu.get('sex', 'unknown')
+        attrs['amplifier'] = eu.get('amplifier', 'unknown')
+        attrs['cap'] = eu.get('cap', 'unknown')
+        attrs['handedness'] = eu.get('handedness', 'unknown')
+    except Exception:
+        for key in ('age', 'gender', 'amplifier', 'cap', 'handedness'):
+            attrs[key] = 'unknown'
+    return attrs

--- a/eegunity/utils/h5.py
+++ b/eegunity/utils/h5.py
@@ -1,6 +1,9 @@
+import json
+import datetime
 import h5py
 import numpy as np
 from pathlib import Path
+
 
 class h5Dataset:
     """
@@ -8,6 +11,13 @@ class h5Dataset:
 
     This class is adapted from:
     https://github.com/935963004/LaBraM/blob/main/dataset_maker/shock/utils/h5.py#L8.
+
+    Atomic write
+    ------------
+    Data is written to ``<name>.hdf5.tmp`` and only renamed to
+    ``<name>.hdf5`` when :meth:`save` is called successfully.
+    If the final ``.hdf5`` file already exists, ``FileExistsError``
+    is raised at construction time so the user can clean up explicitly.
     """
 
     def __init__(self, path: Path, name: str) -> None:
@@ -20,9 +30,25 @@ class h5Dataset:
             The path to the directory containing the HDF5 file.
         name : str
             The name of the HDF5 file (without extension).
+
+        Raises
+        ------
+        FileExistsError
+            If ``<path>/<name>.hdf5`` already exists.
         """
         self.__name = name
-        self.__f = h5py.File(path / f'{name}.hdf5', 'a')
+        self.__final_path = Path(path) / f'{name}.hdf5'
+        self.__tmp_path = Path(path) / f'{name}.hdf5.tmp'
+
+        if self.__final_path.exists():
+            raise FileExistsError(
+                f"HDF5 file already exists: {self.__final_path}. "
+                "Delete it manually before re-exporting."
+            )
+        if self.__tmp_path.exists():
+            self.__tmp_path.unlink()
+
+        self.__f = h5py.File(self.__tmp_path, 'w')
 
     def addGroup(self, grpName: str):
         """
@@ -80,10 +106,9 @@ class h5Dataset:
         src.attrs[f'{attrName}'] = attrValue
 
     def save(self):
-        """
-        Close the HDF5 file.
-        """
+        """Close the tmp file and atomically rename it to the final path."""
         self.__f.close()
+        self.__tmp_path.rename(self.__final_path)
 
     @property
     def name(self):
@@ -98,4 +123,224 @@ class h5Dataset:
         return self.__name
 
 
+class h5EpochDatasetV2:
+    """
+    EEGUnity v2 epoch HDF5 format writer.
 
+    Flat-array layout optimised for PyTorch random access:
+
+    Structure
+    ---------
+    / (root)
+      attrs: version, sfreq, ch_names (JSON), n_channels, n_times,
+             label_map (JSON: code->event_name), n_epochs_total, created_by, created_at
+    ├── data          (N, n_ch, n_times)  float32
+    │                 chunk=(1, n_ch, n_times), gzip level-1
+    ├── epoch_meta/
+    │   ├── source_group  (N,)  variable-length UTF-8 string
+    │   └── event_code    (N,)  int16
+    └── source_meta/
+        └── {group_name}/
+              attrs: file_path, n_epochs_in_source, sfreq,
+                     ch_names (JSON), age, gender, amplifier, cap, handedness
+              └── info  (uint8)  pickled mne.Info bytes
+
+    Usage
+    -----
+    writer = h5EpochDatasetV2(output_dir, "MyDataset")
+    writer.add_epochs(group_name, event_name, epoch_array_float32,
+                      info_bytes, source_attrs, sfreq, ch_names)
+    writer.save()
+
+    Reading in PyTorch
+    ------------------
+    with h5py.File(path, 'r') as f:
+        label_map = json.loads(f.attrs['label_map'])   # {code: event_name}
+        x = f['data'][i]                               # (n_ch, n_times)
+        y = f['epoch_meta/event_code'][i]              # int16
+        grp = f['epoch_meta/source_group'][i]          # bytes/str
+
+    Splitting by source file
+    ------------------------
+    groups = f['epoch_meta/source_group'][:].astype(str)
+    idx = np.where(groups == 'A01T')[0]
+    """
+
+    def __init__(self, path: Path, name: str) -> None:
+        self._final_path = Path(path) / f'{name}.hdf5'
+        self._tmp_path = Path(path) / f'{name}.hdf5.tmp'
+
+        if self._final_path.exists():
+            raise FileExistsError(
+                f"HDF5 file already exists: {self._final_path}. "
+                "Delete it manually before re-exporting."
+            )
+        if self._tmp_path.exists():
+            self._tmp_path.unlink()
+
+        self._f = None
+        self._label_map: dict = {}   # event_name -> int code
+        self._next_code: int = 0
+        self._n_ch: int = None
+        self._n_times: int = None
+        self._source_epoch_counts: dict = {}  # group_name -> cumulative count
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _ensure_initialized(self, n_ch: int, n_times: int,
+                             sfreq: float, ch_names) -> None:
+        if self._f is not None:
+            return
+        self._n_ch = n_ch
+        self._n_times = n_times
+        self._f = h5py.File(self._tmp_path, 'w')
+
+        self._f.attrs['version'] = '2.0'
+        self._f.attrs['sfreq'] = float(sfreq)
+        self._f.attrs['ch_names'] = json.dumps(list(ch_names))
+        self._f.attrs['n_channels'] = int(n_ch)
+        self._f.attrs['n_times'] = int(n_times)
+        self._f.attrs['created_by'] = 'EEGUnity'
+        self._f.attrs['created_at'] = datetime.datetime.now().isoformat()
+
+        self._f.create_dataset(
+            'data',
+            shape=(0, n_ch, n_times),
+            maxshape=(None, n_ch, n_times),
+            dtype='float32',
+            chunks=(1, n_ch, n_times),
+            compression='gzip',
+            compression_opts=1,
+        )
+
+        em = self._f.create_group('epoch_meta')
+        em.create_dataset(
+            'source_group',
+            shape=(0,), maxshape=(None,),
+            dtype=h5py.string_dtype(encoding='utf-8'),
+        )
+        em.create_dataset(
+            'event_code',
+            shape=(0,), maxshape=(None,),
+            dtype='int16',
+        )
+
+        self._f.create_group('source_meta')
+
+    def _get_or_create_code(self, event_name: str) -> int:
+        if event_name not in self._label_map:
+            self._label_map[event_name] = self._next_code
+            self._next_code += 1
+        return self._label_map[event_name]
+
+    def _append_1d(self, ds_name: str, values) -> None:
+        ds = self._f[ds_name]
+        old = ds.shape[0]
+        n = len(values)
+        ds.resize(old + n, axis=0)
+        ds[old:old + n] = values
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def add_epochs(
+        self,
+        group_name: str,
+        event_name: str,
+        epoch_data: np.ndarray,
+        info_bytes: bytes,
+        source_attrs: dict,
+        sfreq: float,
+        ch_names,
+    ) -> None:
+        """
+        Append epochs for one (source_file, event) pair.
+
+        Parameters
+        ----------
+        group_name : str
+            Unique identifier for the source file (e.g. basename without extension).
+        event_name : str
+            Human-readable event / class label.
+        epoch_data : np.ndarray, shape (n_epochs, n_ch, n_times)
+            Epoch array; will be cast to float32.
+        info_bytes : bytes
+            ``pickle.dumps(raw.info)`` from the source file.
+        source_attrs : dict
+            Scalar metadata stored as HDF5 attrs on the source_meta group.
+            Expected keys (all optional): file_path, age, gender, amplifier,
+            cap, handedness.
+        sfreq : float
+            Sampling frequency (used only during lazy initialisation).
+        ch_names : list[str]
+            Channel names (used only during lazy initialisation).
+        """
+        n, n_ch, n_times = epoch_data.shape
+        if n == 0:
+            return
+
+        self._ensure_initialized(n_ch, n_times, sfreq, ch_names)
+
+        if n_ch != self._n_ch or n_times != self._n_times:
+            raise ValueError(
+                f"Epoch shape mismatch for group '{group_name}', event '{event_name}': "
+                f"expected ({self._n_ch}, {self._n_times}), got ({n_ch}, {n_times}). "
+                "Ensure all recordings have the same channel count and epoch length."
+            )
+
+        # ---- Register source_meta (once per source file) ----
+        sm = self._f['source_meta']
+        if group_name not in sm:
+            grp = sm.create_group(group_name)
+            grp.create_dataset(
+                'info',
+                data=np.frombuffer(info_bytes, dtype='uint8'),
+                chunks=None,
+            )
+            grp.attrs['sfreq'] = float(sfreq)
+            grp.attrs['ch_names'] = json.dumps(list(ch_names))
+            for key in ('file_path', 'age', 'gender', 'amplifier', 'cap', 'handedness'):
+                val = source_attrs.get(key, 'unknown')
+                grp.attrs[key] = str(val) if val is not None else 'unknown'
+
+        # ---- Append epoch data ----
+        old_size = self._f['data'].shape[0]
+        self._f['data'].resize(old_size + n, axis=0)
+        self._f['data'][old_size:old_size + n] = epoch_data.astype('float32')
+
+        # ---- Append epoch_meta ----
+        code = self._get_or_create_code(event_name)
+        self._append_1d('epoch_meta/source_group', np.array([group_name] * n, dtype=object))
+        self._append_1d('epoch_meta/event_code', np.full(n, code, dtype='int16'))
+
+        # ---- Update per-source epoch count ----
+        self._source_epoch_counts[group_name] = (
+            self._source_epoch_counts.get(group_name, 0) + n
+        )
+
+    def save(self) -> None:
+        """Finalise the tmp file, then atomically rename it to the final path."""
+        if self._f is None:
+            return
+
+        # Reverse map: int code -> event_name string
+        reverse_map = {int(v): k for k, v in self._label_map.items()}
+        self._f.attrs['label_map'] = json.dumps(reverse_map)
+        self._f.attrs['n_epochs_total'] = int(self._f['data'].shape[0])
+
+        # Persist per-source epoch counts into source_meta attrs
+        sm = self._f['source_meta']
+        for grp_name, count in self._source_epoch_counts.items():
+            if grp_name in sm:
+                sm[grp_name].attrs['n_epochs_in_source'] = int(count)
+
+        self._f.close()
+        self._f = None
+        self._tmp_path.rename(self._final_path)
+
+    @property
+    def name(self) -> str:
+        return self._final_path.stem

--- a/eegunity/utils/split_hdf5_file.py
+++ b/eegunity/utils/split_hdf5_file.py
@@ -1,6 +1,9 @@
 import os
-import h5py
 import shutil
+
+import h5py
+import numpy as np
+
 
 def _get_group_size(group):
     """
@@ -29,87 +32,264 @@ def _get_group_size(group):
     group.visititems(size_visitor_func)
     return total_size
 
-def split_hdf5_file(input_path, max_file_size=10 * 1024**3, output_dir="."):
-    """
-    Split an HDF5 file into multiple parts if its total size exceeds the given limit.
 
-    The minimal splitting unit is a top-level group. If the file size surpasses
-    the specified max_file_size, this function creates multiple output HDF5 files
-    and distributes the top-level groups among them without splitting any single group.
-    Output files are named based on the input file's base name, with suffixes like
-    `_s1.hdf5`, `_s2.hdf5`, etc.
+def _split_v1(input_path, max_file_size, output_dir, base_name):
+    """
+    Split a v1-format HDF5 file into multiple parts by top-level group.
+
+    The minimal splitting unit is one top-level group (one source file).
+    Output files are named ``{base_name}_s1.hdf5``, ``{base_name}_s2.hdf5``, etc.
 
     Parameters
     ----------
     input_path : str
-        Path to the input HDF5 file.
-    max_file_size : int, optional
-        Maximum size in bytes for each output HDF5 file (default is 10GB).
-    output_dir : str, optional
-        Directory where output files will be saved. Defaults to the current directory.
+        Path to the input v1 HDF5 file.
+    max_file_size : int
+        Maximum size in bytes for each output file.
+    output_dir : str
+        Directory where output files will be saved.
+    base_name : str
+        Base name (without extension) for output files.
 
     Returns
     -------
     list of str
-        A list of paths to the generated HDF5 files.
+        Paths to the generated HDF5 files.
     """
-    # Check if input file exists
-    if not os.path.isfile(input_path):
-        raise FileNotFoundError(f"Input file not found: {input_path}")
-
-    # Create output directory if it does not exist
-    os.makedirs(output_dir, exist_ok=True)
-
-    # Extract the base name of the input file (without extension)
-    base_name = os.path.splitext(os.path.basename(input_path))[0]
-
-    # Calculate total size and group sizes
     with h5py.File(input_path, 'r') as f:
-        # Collect top-level groups and their sizes
         groups_info = []
         for name in f.keys():
             obj = f[name]
             if isinstance(obj, h5py.Group):
                 grp_size = _get_group_size(obj)
-                groups_info.append((name, grp_size))
             else:
-                # If top-level item is a dataset (not group), treat it as a "group-like" unit.
                 grp_size = obj.id.get_storage_size()
-                groups_info.append((name, grp_size))
+            groups_info.append((name, grp_size))
 
     total_size = sum(s for _, s in groups_info)
     if total_size <= max_file_size:
-        # Simply copy the original file as is, naming it with _s1 suffix
         output_path = os.path.join(output_dir, f"{base_name}_s1.hdf5")
         shutil.copyfile(input_path, output_path)
         return [output_path]
 
-    # Otherwise, we need to split into multiple files
     output_files = []
     current_file_index = 1
     current_output_path = os.path.join(output_dir, f"{base_name}_s{current_file_index}.hdf5")
     current_out_file = h5py.File(current_output_path, 'w')
     current_used_space = 0
 
-    # We'll re-open the input in read mode for copying groups
     with h5py.File(input_path, 'r') as in_f:
         for grp_name, grp_size in groups_info:
-            # If adding this group exceeds the limit, start a new file
             if current_used_space + grp_size > max_file_size:
                 current_out_file.close()
                 output_files.append(current_output_path)
                 current_file_index += 1
-                current_output_path = os.path.join(output_dir, f"{base_name}_s{current_file_index}.hdf5")
+                current_output_path = os.path.join(
+                    output_dir, f"{base_name}_s{current_file_index}.hdf5")
                 current_out_file = h5py.File(current_output_path, 'w')
                 current_used_space = 0
 
-            # Copy the group to the current output file
             in_f.copy(grp_name, current_out_file)
             current_used_space += grp_size
 
     current_out_file.close()
     output_files.append(current_output_path)
+    return output_files
+
+
+def _split_v2(input_path, max_file_size, output_dir, base_name):
+    """
+    Split a v2-format HDF5 file into multiple parts by source file.
+
+    The minimal splitting unit is all epochs from one source file, keeping
+    epochs from the same source together in the same output file.
+    Each output file is a valid standalone v2 HDF5 with the same root
+    attributes, the global ``label_map``, and only the ``source_meta``
+    entries for sources present in that split.
+
+    Size estimation uses the uncompressed epoch data size
+    (``n_epochs × n_channels × n_times × 4`` bytes, float32), which is a
+    conservative upper bound relative to the gzip-compressed on-disk size.
+
+    Parameters
+    ----------
+    input_path : str
+        Path to the input v2 HDF5 file.
+    max_file_size : int
+        Maximum size in bytes (estimated uncompressed) for each output file.
+    output_dir : str
+        Directory where output files will be saved.
+    base_name : str
+        Base name (without extension) for output files.
+
+    Returns
+    -------
+    list of str
+        Paths to the generated HDF5 files.
+    """
+    with h5py.File(input_path, 'r') as f:
+        n_ch = int(f.attrs['n_channels'])
+        n_times = int(f.attrs['n_times'])
+        label_map = f.attrs['label_map']       # global JSON string; kept in every split
+        root_attrs = dict(f.attrs)             # copy all root attrs
+
+        source_groups_arr = f['epoch_meta/source_group'][:].astype(str)
+        event_codes_arr = f['epoch_meta/event_code'][:]
+
+        # Determine unique source files in order of first appearance
+        seen = set()
+        ordered_sources = []
+        for sg in source_groups_arr:
+            if sg not in seen:
+                seen.add(sg)
+                ordered_sources.append(sg)
+
+        # Build per-source index and size estimate
+        bytes_per_epoch = n_ch * n_times * 4  # float32, uncompressed
+        source_info = {}
+        for src in ordered_sources:
+            indices = np.where(source_groups_arr == src)[0]
+            source_info[src] = {
+                'indices': indices,
+                'estimated_size': len(indices) * bytes_per_epoch,
+            }
+
+        # Pack sources into splits greedily
+        splits = []          # list[list[str]]
+        current_split = []
+        current_size = 0
+        for src in ordered_sources:
+            sz = source_info[src]['estimated_size']
+            if current_split and current_size + sz > max_file_size:
+                splits.append(current_split)
+                current_split = [src]
+                current_size = sz
+            else:
+                current_split.append(src)
+                current_size += sz
+        if current_split:
+            splits.append(current_split)
+
+        # No split needed — just copy
+        if len(splits) == 1:
+            output_path = os.path.join(output_dir, f"{base_name}_s1.hdf5")
+            shutil.copyfile(input_path, output_path)
+            return [output_path]
+
+        # Write each split as a valid v2 file
+        output_files = []
+        for split_idx, sources_in_split in enumerate(splits, start=1):
+            output_path = os.path.join(output_dir, f"{base_name}_s{split_idx}.hdf5")
+
+            # Gather and sort epoch indices for this split
+            all_indices = np.concatenate(
+                [source_info[src]['indices'] for src in sources_in_split])
+            all_indices.sort()
+            n_epochs_split = len(all_indices)
+
+            with h5py.File(output_path, 'w') as out_f:
+                # ---- Root attributes ----
+                for k, v in root_attrs.items():
+                    if k == 'n_epochs_total':
+                        continue          # written below with correct count
+                    out_f.attrs[k] = v
+                out_f.attrs['label_map'] = label_map   # global map (Q2: B)
+                out_f.attrs['n_epochs_total'] = n_epochs_split
+
+                # ---- data ----
+                epoch_data = f['data'][all_indices]    # fancy indexing (sorted)
+                out_f.create_dataset(
+                    'data',
+                    data=epoch_data.astype('float32'),
+                    chunks=(1, n_ch, n_times),
+                    compression='gzip',
+                    compression_opts=1,
+                )
+
+                # ---- epoch_meta ----
+                em = out_f.create_group('epoch_meta')
+                em.create_dataset(
+                    'source_group',
+                    data=source_groups_arr[all_indices],
+                    dtype=h5py.string_dtype(encoding='utf-8'),
+                )
+                em.create_dataset(
+                    'event_code',
+                    data=event_codes_arr[all_indices],
+                )
+
+                # ---- source_meta (only sources present in this split) ----
+                sm_out = out_f.create_group('source_meta')
+                sm_in = f['source_meta']
+                for src in sources_in_split:
+                    if src not in sm_in:
+                        continue
+                    f.copy(f'source_meta/{src}', sm_out)
+                    # Overwrite n_epochs_in_source with the count in this split
+                    sm_out[src].attrs['n_epochs_in_source'] = int(
+                        len(source_info[src]['indices']))
+
+            output_files.append(output_path)
 
     return output_files
 
 
+def split_hdf5_file(input_path, max_file_size=10 * 1024 ** 3, output_dir="."):
+    """
+    Split an HDF5 file into multiple parts if its total size exceeds the given limit.
+
+    Both v1 (file-per-group) and v2 (flat-array) EEGUnity HDF5 formats are
+    supported.  The format is detected automatically from the root ``version``
+    attribute.
+
+    **v1 behaviour** — The minimal splitting unit is one top-level group (one
+    source file).  Groups are accumulated greedily and a new output file is
+    started whenever adding the next group would exceed ``max_file_size``.
+
+    **v2 behaviour** — The minimal splitting unit is all epochs from one
+    source file (epochs from the same source are never split across files).
+    Size is estimated from uncompressed epoch data
+    (``n_epochs × n_channels × n_times × 4`` bytes).  Each output file is a
+    fully self-contained v2 HDF5 that shares the global ``label_map`` of the
+    source file and contains only the ``source_meta`` entries relevant to that
+    split.
+
+    If the file fits within ``max_file_size`` a single ``_s1`` copy is
+    returned without modification.
+
+    Parameters
+    ----------
+    input_path : str
+        Path to the input HDF5 file.
+    max_file_size : int, optional
+        Maximum size in bytes for each output HDF5 file (default is 10 GB).
+        For v2 files this is compared against the *uncompressed* epoch data
+        size, which is a conservative upper bound.
+    output_dir : str, optional
+        Directory where output files will be saved. Defaults to the current
+        directory.
+
+    Returns
+    -------
+    list of str
+        A list of paths to the generated HDF5 files.
+
+    Raises
+    ------
+    FileNotFoundError
+        If ``input_path`` does not exist.
+    """
+    if not os.path.isfile(input_path):
+        raise FileNotFoundError(f"Input file not found: {input_path}")
+
+    os.makedirs(output_dir, exist_ok=True)
+    base_name = os.path.splitext(os.path.basename(input_path))[0]
+
+    # Detect format from root attribute
+    with h5py.File(input_path, 'r') as f:
+        version = f.attrs.get('version', None)
+
+    if version is not None and str(version).startswith('2'):
+        return _split_v2(input_path, max_file_size, output_dir, base_name)
+    else:
+        return _split_v1(input_path, max_file_size, output_dir, base_name)


### PR DESCRIPTION
…ecation

- Add h5EpochDatasetV2: flat (N, n_ch, n_times) float32 layout with gzip-1 compression and per-epoch chunking for PyTorch-friendly random access
- Add atomic write to h5Dataset and h5EpochDatasetV2: write to .hdf5.tmp, rename to .hdf5 on save(); raise FileExistsError if target already exists
- Add pipeline: Optional[Callable] = None to epoch_by_event_hdf5, epoch_by_segmentation_hdf5, epoch_by_long_event_hdf5, and export_h5Dataset; execution order: load -> pipeline -> resample (resample always last)
- Add format_version='v2' (default) / 'v1' (DeprecationWarning) to all three HDF5 epoch methods; v1 logic delegated to private _*_v1 helpers
- Raise NotImplementedError on epoch_by_event and epoch_by_long_event (npy); direct users to HDF5 equivalents
- Add include_events whitelist param to event-based epoch methods
- Update split_hdf5_file to auto-detect v1/v2 format; v2 splits by source file keeping per-source epochs together, preserves global label_map and writes only relevant source_meta entries per split
- Bump version to 0.8.0